### PR TITLE
Bubblewrap and WSL2: Profiles and GUI Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,19 @@ Running the demo project may fail with the following error on ubuntu 24.04:
 
     bwrap: setting up uid map: Permission denied
 
-This is due to Ubuntu developers deciding to use Apparmor to restrict the creation of user namespaces. To resolve this create a file named `/etc/apparmor.d/bwrap` with the following contents:
+This is due to the Ubuntu developers' decision to use AppArmor to restrict the creation of user namespaces. Below are the steps for applying a new AppArmor profile to enable user namespace restriction:
 
-    abi <abi/4.0>,
-    include <tunables/global>
+```sh
+# Download the new profile:
 
-    profile bwrap /usr/bin/bwrap flags=(unconfined) {
-      userns,
+sudo wget -O /etc/apparmor.d/bwrap-userns-restrict "https://gitlab.com/apparmor/apparmor/-/raw/master/profiles/apparmor/profiles/extras/bwrap-userns-restrict?ref_type=heads&inline=false"
 
-      # Site-specific additions and overrides. See local/README for details.
-      include if exists <local/bwrap>
-    }
+# Load the new profile into AppArmor:
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
-Followed by a reboot. 
-(Note: this fix was found [here](https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/))
+# Restart the AppArmor service:
+sudo systemctl restart apparmor
+```
 
 ## Usage
 See the project in [WebKitGtk.Test](https://github.com/JinShil/BlazorWebView/tree/main/WebKitGtk.Test) for an example illustrating how to create a Blazor Hybrid application using the BlazorWebView.
@@ -53,7 +52,7 @@ You may need to install the following packages:
 
 ## Status
 This project was tested on:
-- Windows Subsystem for Linux
+- Windows Subsystem for Linux. Detailed setup instructions are available [here](./WSL2.md).
 - Raspberry Pi Bullseye 64-bit
 - Debian Bullseye 64-bit.
 - Ubuntu 24.04 LTS desktop amd64

--- a/WSL2.md
+++ b/WSL2.md
@@ -1,0 +1,117 @@
+# WSL2 Setup Guide
+
+## Installing WSL2
+
+1. **Open a PowerShell window with administrative privileges.**
+2. **Run the following commands to enable WSL and Virtual Machine Platform features:**
+
+    ```powershell
+    dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+    dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
+
+    # Restart your computer to apply changes
+    Restart-Computer
+    ```
+
+## Updating WSL2 Kernel and Installing Ubuntu 24.04
+
+1. **After restarting, open PowerShell.**
+2. **Update the WSL kernel:**
+
+    ```powershell
+    wsl --update
+    ```
+
+3. **Set WSL2 as the default version:**
+
+    ```powershell
+    wsl --set-default-version 2
+    ```
+
+4. **Install Ubuntu 24.04:**
+
+    ```powershell
+    wsl --install -d Ubuntu-24.04
+    ```
+
+5. **Update Ubuntu packages after installation:**
+
+    ```bash
+    sudo apt update && sudo apt full-upgrade -y
+    ```
+
+## Setting Up WSL2 GUI (WSLg Links)
+
+For more information about the WSLg Links project, visit [viruscamp WSLg Links](https://github.com/viruscamp/wslg-links).
+
+1. **Install WSLg Links:**
+
+    ```bash
+    # Using unzip (if installed)
+    # sudo apt install unzip
+    wget https://github.com/viruscamp/wslg-links/archive/refs/heads/main.zip
+    unzip main.zip && cd wslg-links-main
+
+    # Using git (if installed)
+    # sudo apt install git
+    git clone https://github.com/viruscamp/wslg-links.git
+    cd wslg-links
+
+    sudo cp wslg-tmp-x11.service /usr/lib/systemd/system/
+    sudo cp wslg-runtime-dir.service /usr/lib/systemd/user/
+    sudo systemctl enable wslg-tmp-x11
+    sudo systemctl --global enable wslg-runtime-dir
+    exit
+    ```
+
+2. **Shutdown WSL:**
+
+    ```powershell
+    wsl --shutdown
+    ```
+
+## Configuring WSL2 GUI Environment Variables
+
+1. **Open the Ubuntu terminal in WSL2:**
+
+    ```powershell
+    wsl -d Ubuntu-24.04 --cd ~
+    ```
+
+### CPU Rendering (Faster but Uses CPU Only)
+
+```bash
+export LIBGL_ALWAYS_SOFTWARE=true
+export GALLIUM_DRIVER=llvmpipe
+# Alternative:
+# export GALLIUM_DRIVER=softpipe
+```
+
+### GPU Rendering (Requires Compatible Hardware)
+
+Follow the [Microsoft WSL2 GUI setup documentation](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps#prerequisites) for prerequisites. (Installed driver for vGPU)
+
+#### For Intel GPUs
+
+```bash
+export GALLIUM_DRIVER=d3d12
+export MESA_D3D12_DEFAULT_ADAPTER_NAME=INTEL
+```
+
+#### For NVIDIA GPUs
+
+```bash
+export GALLIUM_DRIVER=d3d12
+export MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA
+```
+
+#### For AMD GPUs (Not Tested)
+
+```bash
+export GALLIUM_DRIVER=d3d12
+export MESA_D3D12_DEFAULT_ADAPTER_NAME=AMD
+```
+
+---
+
+This guide provides a comprehensive setup for WSL2 with Ubuntu 24.04, including optional GUI configurations. Ensure all dependencies are installed as needed.


### PR DESCRIPTION
Hello Mike,

I have updated the AppArmor section; this profile will be included in future Ubuntu releases.

I saw the WSL2 issue ticket. I have created a documentation on how to run graphical applications. This isn't limited to running Blazor; it works for anything, such as Nautilus, GNOME Terminal, etc.
